### PR TITLE
Update area names and improve badge visibility on smaller screens

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -204,8 +204,12 @@ function get_chaside_summary_complete($chaside_data) {
     if (($max_percentage - $min_percentage) > 30) {
         $html .= '<div class="gap-alerts-summary mb-3">';
         $html .= '<h6>⚠️ Alertas de Desarrollo</h6>';
-        $html .= '<span class="badge badge-warning">Brecha significativa detectada (' . 
-                round($max_percentage - $min_percentage, 1) . '% diferencia)</span>';
+        $html .= '<div style="text-align: center;">';
+        $html .= '<span class="badge badge-warning" style="display: inline-block; white-space: normal; max-width: 100%; text-align: center;">';
+        $html .= 'Brecha significativa detectada ';
+        $html .= '<span style="white-space: nowrap;">(' . round($max_percentage - $min_percentage, 1) . '% diferencia)</span>';
+        $html .= '</span>';
+        $html .= '</div>';
         $html .= '</div>';
     }
     


### PR DESCRIPTION
This PR updates the correct area names that `get_chaside_area_name` should return. It also improves the visibility of the "Brecha significativa detectada" badge on screens with a resolution lower than 2K.